### PR TITLE
awk count strings from 1 not 0. Couting from 0 broke mawk implementation

### DIFF
--- a/bird/agents/plugins/bird
+++ b/bird/agents/plugins/bird
@@ -20,7 +20,7 @@
 #
 # Copyright 2014 by Frederik Kriewitz <frederik@kriewitz.eu>.
 
-MODIFIER='{if($1 ~ /^[0-9][0-9][0-9][0-9]\-/) {code=substr($1,0,4);print code, substr($0,6)} else if ($0 ~ /^ /) {print code $0} else {print}}'
+MODIFIER='{if($1 ~ /^[0-9][0-9][0-9][0-9]\-/) {code=substr($1,1,4);print code, substr($0,6)} else if ($0 ~ /^ /) {print code $0} else {print}}'
 
 for VERSION in "" "6"
 do


### PR DESCRIPTION
```
undefine@undefine-ThinkPad-T430s:~$ echo x |mawk '{print substr("012345",0,4)}'
012
undefine@undefine-ThinkPad-T430s:~$ echo x |gawk '{print substr("012345",0,4)}'
0123

```