### PR TITLE
OSPF state 2-way should not trigger a warning.

### DIFF
--- a/bird/checks/bird.include
+++ b/bird/checks/bird.include
@@ -434,7 +434,7 @@ def check_bird_protocols(item, params, info):
 
         for neighbour in protocol['neighbours']:
             neighbour_state = neighbour['State'].split("/")[0]
-            if neighbour_state.lower() != "full": # bird <=1.5 state is full, bird >= 1.5 state is Full (uppercase)
+            if neighbour_state.lower() not in ["full", "2-way"]: # bird <=1.5 state is full, bird >= 1.5 state is Full (uppercase)
                 infotxts.append("state of %s is %s(!)" % (neighbour['Router_IP'], neighbour_state))
                 state = max(state, 1)
 


### PR DESCRIPTION
Hi,

the OSPF state 2-Way should not trigger a WARNING state since this is a valid state on broadcast domains with multiple OSPF routers (see also [Cisco docs](https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13685-13.html#twoway)).


HTH,
Thomas