### PR TITLE
fix 2 parsing bugs

### DIFF
--- a/bird/lib/check_mk/base/plugins/agent_based/bird.py
+++ b/bird/lib/check_mk/base/plugins/agent_based/bird.py
@@ -137,7 +137,7 @@ def _bird_strptime(string):
 
 def _bird_si_to_int(value, unit):
     _prefix = {'': 1, 'k': 1024, 'M': 1048576, 'G': 1073741824}
-    return int(value) * _prefix[unit.rstrip('B')]
+    return int(value.split(".")[0]) * _prefix[unit.rstrip('B')]
 
 def _bird_x_to_key(value):
     return "_".join(value).rstrip(':')
@@ -319,7 +319,7 @@ def check_bird_memory(params, section) -> CheckResult:
                      summary="No memory data available")
         return
     for name, value_text, value_bytes in section['memory']:
-        key = name.replace(" ", "_")
+        key = name.replace(" ", "_").split(":")[0]  # memory part wasn't parsed correctly, quick fix
         warn, crit = params.get('memory_levels_'+key, (None, None))
         yield from check_levels(value_bytes,
                                 levels_upper=(warn, crit),


### PR DESCRIPTION
Fix for 2 parsing bugs for bird2.

1. Bug: Values from Memory are parsed as integers, but can be floats.
2. Bug: ":"

```
<<<bird>>>
0001 BIRD 2.0.10 ready.
1000 BIRD 2.0.10
[..]
1018 BIRD memory usage
1018                       Effective    Overhead
1018     Routing tables:    614.7 kB    333.7 kB   -> ":" and values are floats, both not correctly parsed
1018     Route attributes:  273.0 kB    107.1 kB
1018     Protocols:        3887.0 kB    154.9 kB
1018     Standby memory:      0.0  B   2048.0 kB
1018     Total:            4848.4 kB   2647.7 kB
[..]
```

Fix this by reducing float strings to int string and removing ":" from Metric string by spliting.
