### PR TITLE
agent_based: expand fix for bounds variable update

### DIFF
--- a/bird/agent_based/bird.py
+++ b/bird/agent_based/bird.py
@@ -404,7 +404,12 @@ def check_bird_protocols(item, params, section) -> CheckResult:
     for key, value in protocol.get('route_stats', {}).items():
         bounds = limit_bounds.get(key, {})
         if key in route_stats_levels:
-            bounds.update({key: ("fixed", route_stats_levels[key])})
+            for direction in route_stats_levels[key]:
+                blimits = route_stats_levels[key][direction]
+                if blimits[0] in ["fixed", "no_levels"]:
+                    bounds[direction] = route_stats_levels[key][direction]
+                else:
+                    bounds[direction] = ("fixed", route_stats_levels[key][direction])
         yield from check_levels(
             value,
             levels_upper=bounds.get('upper'),


### PR DESCRIPTION
Theres a special case in my previous fix https://github.com/freddy36/check_mk_extensions/pull/20 , which wasn't handled:

Sometimes, the dictionary construction has an additional Tuple layer `('fixed': (..))` somewhere in the code.

This PR checks handles this by checking the tuple values.

example:
```
route_stats_levels:
  item1: {'imported': {'lower': ('no_levels', None), 'upper': ('fixed', (10, 20))}}
  item2: {'exported': {'lower': (0, 0), 'upper': (2, 2)}, 'imported': {'lower': (0, 0), 'upper': (2, 2)}}
```